### PR TITLE
fix regex, allow trailing whitespace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const isNullOrUndefined = require('./helpers/is-null-or-undefined');
 const VNodeFlags = require('./flags');
 
 function handleWhiteSpace(str) {
-	return str.replace(/^[\s\t]+|[\s\t]+$|([\r\n])|(\s+)(?=\s)/g, '');
+	return str.replace(/^[\s\t]+|([\r\n])|(\s+)(?=\s)/g, '');
 }
 
 function hasHyphenOrColon(attr) {


### PR DESCRIPTION
Allows the `example.js` to return:

```js
createVNode(2, 'div', null, ['Hello world, ', ['Foo!', 'Bar!']]);
```

Similarly:

```js
`
        <p>
          This should have
          no new lines in it
          or spaces at start
          and end
        </p>
`

//=> <p> This should have no new lines in it or spaces at start and end </p>
```