### PR TITLE
Manually convert JSXIdentifier and JSXMemberExpression to literals

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var isComponent = require('./helpers/is-component');
 var isNullOrUndefined = require('./helpers/is-null-or-undefined');
+var toReference = require('./helpers/to-reference');
 var VNodeFlags = require('inferno-vnode-flags');
 var svgAttributes = require('./attrsSVG');
 var NULL;
@@ -91,6 +92,7 @@ function getVNodeType(t, type) {
 	if (astType === 'JSXIdentifier') {
 		if (isComponent(type.name)) {
 			component = true;
+			type = toReference(t, type, true);
 			flags = VNodeFlags.ComponentUnknown;
 		} else {
 			var tag = type.name;
@@ -118,6 +120,7 @@ function getVNodeType(t, type) {
 		}
 	} else if (astType === 'JSXMemberExpression') {
 		component = true;
+		type = toReference(t, type, true);
 		flags = VNodeFlags.ComponentUnknown;
 	}
 	return {

--- a/tests.js
+++ b/tests.js
@@ -41,7 +41,11 @@ describe('Array', function() {
 		});
 
 		it('className should be in fifth parameter as string when its component', function () {
-			expect(transform('<UnkownClass className="first second">1</UnkownClass>')).to.equal('createVNode(16, UnkownClass, null, null, {\n  "className": "first second",\n  children: "1"\n});');
+			expect(transform('<UnknownClass className="first second">1</UnknownClass>')).to.equal('createVNode(16, UnknownClass, null, null, {\n  "className": "first second",\n  children: "1"\n});');
+		});
+
+		it('JSXMemberExpressions should work', function () {
+			expect(transform('<Components.Unknown>1</Components.Unknown>')).to.equal('createVNode(16, Components.Unknown, null, null, {\n  children: "1"\n});');
 		});
 
 		it('class should be in third parameter as variable', function () {


### PR DESCRIPTION
I've tested this against Babel 7.0.0-beta.37 locally using nwb's Babel 7 branch, not sure if you want to update `devDependencies` to use a beta version.

Also added a test to also cover use of `JSXMemberExpression`s.

Fixes #46