### PR TITLE
Create references for JSXIdentifier and JSXMemberExpression VNodeTypes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,18 @@ function handleWhiteSpace(value) {
   return '';
 }
 
+function jsxMemberExpressionReference(t, node) {
+  if (t.isJSXIdentifier(node)) {
+    return t.identifier(node.name);
+  }
+  if (t.isJSXMemberExpression(node)) {
+    return t.memberExpression(
+      jsxMemberExpressionReference(t, node.object),
+      jsxMemberExpressionReference(t, node.property)
+    );
+  }
+}
+
 function getVNodeType(t, type) {
   var astType = type.type;
   var component = false;
@@ -74,6 +86,7 @@ function getVNodeType(t, type) {
   if (astType === 'JSXIdentifier') {
     if (isComponent(type.name)) {
       component = true;
+      type = t.identifier(type.name);
       flags = VNodeFlags.ComponentUnknown;
     } else {
       var tag = type.name;
@@ -98,6 +111,7 @@ function getVNodeType(t, type) {
     }
   } else if (astType === 'JSXMemberExpression') {
     component = true;
+    type = jsxMemberExpressionReference(t, type);
     flags = VNodeFlags.ComponentUnknown;
   }
   return {

--- a/tests.js
+++ b/tests.js
@@ -8,7 +8,7 @@ var babel = require('babel-core');
 var babelSettings = {
 	presets: [['es2015', {modules: false}]],
 	plugins: [
-		[plugin, {imports: false}],
+		[plugin, {imports: true}],
 		'syntax-jsx'
 	]
 };
@@ -141,7 +141,11 @@ describe('Transforms', function() {
 		});
 
 		it('className should be in fifth parameter as string when its component', function () {
-			expect(transform('<UnkownClass className="first second">1</UnkownClass>')).to.equal('createComponentVNode(2, UnkownClass, {\n  "className": "first second",\n  children: "1"\n});');
+			expect(transform('<UnknownClass className="first second">1</UnknownClass>')).to.equal('createComponentVNode(2, UnknownClass, {\n  "className": "first second",\n  children: "1"\n});');
+		});
+
+		it('JSXMemberExpressions should work', function () {
+			expect(transform('<Components.Unknown>1</Components.Unknown>')).to.equal('createComponentVNode(2, Components.Unknown, {\n  children: "1"\n});');
 		});
 
 		it('class should be in third parameter as variable', function () {


### PR DESCRIPTION
v4-beta version of the fix for #46 - pulled in the relevant portion of the old `toReference` helper function which is no longer in this branch.

Also had to flip the `imports` config to get the tests to pass.