### PR TITLE
Use SpreadElement instead of SpreadProperty when available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -269,9 +269,12 @@ function getVNodeProps(t, astProps, isComponent) {
 	return {
 		props: isNullOrUndefined(props) ? NULL : props = t.ObjectExpression(
 			props.map(function (prop) {
-				return !prop.astSpread
-					? t.ObjectProperty(prop.astName, prop.astValue)
-					: t.SpreadProperty(prop.astSpread);
+				if (prop.astSpread) {
+					var SpreadElement = t.SpreadElement || t.SpreadProperty;
+					return SpreadElement(prop.astSpread);
+				}
+
+				return t.ObjectProperty(prop.astName, prop.astValue);
 			})
 		),
 		key: isNullOrUndefined(key) ? NULL : key,


### PR DESCRIPTION
My project is seeing the following when using the latest Babel 7 alpha.

```
Trace: The node type SpreadProperty has been renamed to SpreadElement
```

This pull request changes the logic to use `SpreadElement` when it is present but still fallback to `SpreadProperty` in the event `SpreadElement` is not present.