### PR TITLE
Relax Node.js requirement to 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "@babel/types": "^7"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
Travis CI tests will fail if the engine requirement isn't satisfied and Node 6.x is still active. Tried transpiling with Node 6.14 and it works.